### PR TITLE
Implement error handling for collections

### DIFF
--- a/src/no-sql-db.interface.ts
+++ b/src/no-sql-db.interface.ts
@@ -58,7 +58,7 @@ export interface INoSqlDatabase {
   readCollection<T>(args: {
     path: CollectionPath;
     constraints?: Array<NoSqlDbQueryConstraint<T>>;
-  }): Promise<Array<{ data: T; id: string }>>; //TODO: Add error handling not-found
+  }): Promise<Result<Array<{ data: T; id: string }>, ErrorWithCode<"not-found">>>;
   addToCollection<T>(path: CollectionPath, data: T): Promise<{ id: string }>;
   deleteCollection(path: CollectionPath): Promise<void>;
 }

--- a/src/provider/fake/database.fake.ts
+++ b/src/provider/fake/database.fake.ts
@@ -81,11 +81,11 @@ export class NoSqlDatabaseTesting implements INoSqlDatabase {
   public async readCollection<T>(args: {
     path: CollectionPath;
     constraints?: Array<NoSqlDbQueryConstraint<T>>;
-  }): Promise<Array<{ data: T; id: string }>> {
+  }): Promise<Result<Array<{ data: T; id: string }>, ErrorWithCode<"not-found">>> {
     await this.simulateCommunicationDelay();
     const collection = this.getElementAtPath(args.path);
     if (!collection || typeof collection !== "object") {
-      return [];
+      return resultError.withCode("not-found");
     }
 
     let documents = Object.entries(collection).map(([id, doc]) => ({
@@ -93,7 +93,7 @@ export class NoSqlDatabaseTesting implements INoSqlDatabase {
       data: doc as T,
     }));
 
-    if (!args.constraints) return documents;
+    if (!args.constraints) return resultSuccess(documents);
 
     for (const constraint of args.constraints) {
       if (constraint.type === "where") {
@@ -127,7 +127,7 @@ export class NoSqlDatabaseTesting implements INoSqlDatabase {
       }
     }
 
-    return documents;
+    return resultSuccess(documents);
   }
 
   private getElementAtPath(path: NoSqlDbPath): any {

--- a/src/schema/collections/db-collections.interface.ts
+++ b/src/schema/collections/db-collections.interface.ts
@@ -14,7 +14,7 @@ export interface IDatabaseCollections<TIdentifier, TData> {
   readAll(args: {
     identifier: TIdentifier;
     constraints?: Array<NoSqlDbQueryConstraint<TData>>;
-  }): Promise<Array<{ data: TData; id: DocumentId }>>;
+  }): Promise<Result<Array<{ data: TData; id: DocumentId }>, ErrorWithCode<'not-found'>>>;
   write(args: {
     identifier: TIdentifier;
     id: DocumentId;

--- a/src/schema/collections/db-collections.ts
+++ b/src/schema/collections/db-collections.ts
@@ -50,10 +50,10 @@ export class DatabaseCollections<TCollectionIdentifier, TData>
   public async readAll<TData>(args: {
     identifier: TCollectionIdentifier;
     constraints?: Array<NoSqlDbQueryConstraint<TData>>;
-  }): Promise<Array<{ data: TData; id: DocumentId }>> {
+  }): Promise<Result<Array<{ data: TData; id: DocumentId }>, ErrorWithCode<"not-found">>> {
     const { identifier } = args;
     const path = this.getCollectionPath(identifier);
-    const result = this.db.readCollection<TData>({
+    const result = await this.db.readCollection<TData>({
       path,
       constraints: args.constraints,
     });


### PR DESCRIPTION
Error handling for the `readCollection` method was implemented to align with `readDocument`'s pattern.

*   The `readCollection` method in `src/no-sql-db.interface.ts` was updated to return `Promise<Result<Array<{ data: T